### PR TITLE
Fix photo z-index link

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -297,6 +297,8 @@ a:hover {
       /*padding: 0 0 1em 1em;*/
       display: block;
       margin-bottom: 0.5em;
+      position: relative;
+      z-index: 5;
       }
     .vcard .vcard-export {
       background-image: url(../img/vcard.png);


### PR DESCRIPTION
This allows you to click on an employee's photo at any point; previously the image was only clickable on the top-half.
