### PR TITLE
Fix Bug 1141421 - search strings are not url decoded, resulting in invalid searches

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -7,7 +7,7 @@ if (!window.console) {
 (function() {
   var hash = window.location.hash;
   var fire = function(str) {
-    $(document).fire("hash:changed", { hash: str.substring(1) });
+    $(document).fire("hash:changed", { hash: decodeURIComponent(str.substring(1)) });
   };
   var pe = new PeriodicalExecuter(function() {
     var newHash = window.location.hash;
@@ -230,7 +230,7 @@ var SearchManager = {
   onLoad: function onLoad() {
     if (window.location.hash.startsWith("#search/")) {
       $(document).fire("hash:changed", {
-        hash: window.location.hash.substring(1)
+        hash: decodeURIComponent(window.location.hash.substring(1))
       });
     } else {
       $("phonebook-search").addClassName("large");

--- a/js/view-tree.js
+++ b/js/view-tree.js
@@ -214,10 +214,10 @@ Object.extend(SearchManager, {
   onLoad: function() {
     var hash = window.location.hash;
     if (hash.startsWith("#search/")) {
-      var search = hash.replace(/^#search\//, '');
+      var search = decodeURIComponent(hash.replace(/^#search\//, ''));
       if (!search.strip()) { return; }
       $("text").value = search;
-      $(document).fire("hash:changed", {hash: hash.substring(1)});
+      $(document).fire("hash:changed", {hash: decodeURIComponent(hash.substring(1))});
     }
   }
 });


### PR DESCRIPTION
See the [Firefox 41 site compatibility doc](https://developer.mozilla.org/en-US/Firefox/Releases/41/Site_Compatibility#URLUtils.hash_no_longer_decodes_fragment) for the background.
