### PR TITLE
Remove ability for even an admin to edit Desk Number attribute

### DIFF
--- a/edit.php
+++ b/edit.php
@@ -27,6 +27,12 @@ if (!empty($_POST)) {
         } 
         $new_user_data[$editable_field] = $_POST[$editable_field];
     }
+    if(isset($new_user_data["other"][0])){
+        $new_user_data["other"][0] = strip_tags($new_user_data["other"][0]);
+    }
+    if(isset($new_user_data["description"][0])){
+        $new_user_data["description"][0] = strip_tags($new_user_data["description"][0]);
+    }
   }
 
   $edit->cook_incoming($new_user_data, $is_admin);

--- a/templates/edit.php
+++ b/templates/edit.php
@@ -90,14 +90,10 @@ $counter++;
   </tr>
   <tr>
     <td><label>Desk Number</label></td>
-  <?php if($is_admin){ ?>
-    <td><input type="text" name="roomNumber[]" value="<?php echo escape($user_data['roomnumber'][0]) ?>"/></td>
-  <?php } else { ?>
     <td>
       <span><?php echo $user_data['roomnumber'][0] ?></span><br />
       <em class="description">Please file a Service Now ticket if your location is incorrect/if you'd like to move.</em>
     </td>
-  <?php } ?>
   </tr>
   <tr>
     <td><label>Title</label></td>


### PR DESCRIPTION
We're going to start to sync RoomNumber as seen in LDAP or Desk Number as it is displayed in the phonebook interface. I honestly don't know how often an admin has ever even updated this manually anyway.

I've removed the conditional that allows an admin to edit this value.
