### PR TITLE
Revert "Move LDAP sanitization to ldap_escape"

### DIFF
--- a/edit.php
+++ b/edit.php
@@ -7,11 +7,13 @@ error_reporting(E_ERROR);
 $edit = new MozillaEditingAdapter();
 $auth = new MozillaAuthAdapter();
 $search = new MozillaSearchAdapter($ldapconn);
-$user = ldap_escape($_SERVER["PHP_AUTH_USER"], null, LDAP_ESCAPE_FILTER);
+
+$ldap_char_blacklist = array("*", "&", "|", "(", ")", "=");
+$user = str_replace($ldap_char_blacklist, "", $_SERVER["PHP_AUTH_USER"]);
 
 $is_admin = $auth->is_phonebook_admin($ldapconn, $auth->user_to_dn($user));
 if (isset($_REQUEST["edit_mail"]) && $is_admin) {
-  $edit_user = ldap_escape($_REQUEST["edit_mail"], null, LDAP_ESCAPE_FILTER);
+  $edit_user = str_replace($ldap_char_blacklist, "", $_REQUEST["edit_mail"]);
 } else {
   $edit_user = $auth->user_to_email($user);
 }


### PR DESCRIPTION
This reverts commit 11d86194afe5663b46ecbf71cfbfddfaadc8f1a2.

This causes errors in production; it's possible we don't have the right
LDAP stuff installed there.
