### PR TITLE
Various cleanups for production phonebook

### DIFF
--- a/config-local.php-dist
+++ b/config-local.php-dist
@@ -13,4 +13,4 @@ define("MEMCACHE_ENABLED", true);
 $memcache_servers = array(
     'localhost:11211',
 );
-define('MEMCACHE_PREFIX', 'phonebook');
+define('MEMCACHE_PREFIX', 'phonebook-default');

--- a/config-local.php-dist
+++ b/config-local.php-dist
@@ -7,6 +7,7 @@
 
 // LDAP
 define('LDAP_HOST', 'pm-ns.mozilla.org');
+define('LDAP_EXCLUDE', '');  // '(!(defaultAttribute=defaultValue))'
 
 // Memcache (port number is mandatory)
 define("MEMCACHE_ENABLED", true);

--- a/config.php
+++ b/config.php
@@ -154,6 +154,15 @@ class MozillaEditingAdapter extends EditingAdapter {
 /*************************************************************************/
 
 class MozillaSearchAdapter extends SearchAdapter {
+
+  function __construct($auth){
+    $ldapconn = get_ldap_connection();
+    parent::__construct($ldapconn);
+    $this->auth = new MozillaAuthAdapter();
+    $this->dn = $this->auth->user_to_dn($_SERVER["PHP_AUTH_USER"]);
+    $this->phonebook_admin = $this->auth->is_phonebook_admin($ldapconn, $this->dn);
+  }
+
   public $fields = array(
     'cn', 'title', 'telephoneNumber', 'mobile', 'description', 'manager',
     'other', 'im', 'mail', 'emailAlias', 'physicalDeliveryOfficeName',
@@ -196,6 +205,10 @@ class MozillaSearchAdapter extends SearchAdapter {
       $escaped = escape_ldap_filter_value($search);
       $filter = "(mail=$escaped)";
     }
+    if (!$this->phonebook_admin) {
+      $filter = '(&(!(employeeType=DISABLED))' . $filter . ')';
+    }
+
     return $this->query_users($filter, 'dc=mozilla', $this->fields);
   }
 

--- a/config.php
+++ b/config.php
@@ -4,8 +4,11 @@
 require_once('constants.php');
 
 
-if (!defined('LDAP_HOST'))
-    define('LDAP_HOST', 'pm-ns.mozilla.org');
+if (!defined('LDAP_HOST')) {
+    header('HTTP/1.0 500 LDAP Error');
+    print('LDAP_HOST is not defined!');
+    die;
+}
 
 /*************************************************************************/
 

--- a/config.php
+++ b/config.php
@@ -199,6 +199,9 @@ class MozillaSearchAdapter extends SearchAdapter {
             }
             $filter .= "(|$subfilter)";
         }
+        if (LDAP_EXCLUDE != '') {
+            $filter = $filter . LDAP_EXCLUDE;
+        }
         $filter = "(&$filter)";
       }
     } else {

--- a/css/style.css
+++ b/css/style.css
@@ -629,7 +629,6 @@ div.tree ul {
 
     div.tree ul li.disabled {
       opacity: 0.65;
-      filter: url(effects.svg#fog);
       }
       div.tree ul li.disabled a {
         color: #666;
@@ -712,10 +711,6 @@ div.photo-frame {
     -webkit-box-shadow: 0 0 16px #333;
     }
 
-  div.photo-frame.disabled {
-    filter: url(effects.svg#fog);
-    }
-
 #overlay {
   position: fixed;
   top: 0;
@@ -750,9 +745,3 @@ div.photo-frame {
 body.lightbox #overlay {
   display: block;
   }
-
-body.lightbox #header,
-body.lightbox #results {
-  filter: url(effects.svg#blur);
-  }
-

--- a/functions.php
+++ b/functions.php
@@ -22,7 +22,6 @@ function get_ldap_connection() {
     // Check for validity of login
     if ($auth->check_valid_user($_SERVER["PHP_AUTH_USER"])) {
       $user_dn = $auth->user_to_dn($_SERVER["PHP_AUTH_USER"]);
-      $password = $_SERVER["PHP_AUTH_PW"];
     } else {
       wail_and_bail();
     }

--- a/tree.php
+++ b/tree.php
@@ -10,9 +10,12 @@ $auth = new MozillaAuthAdapter();
 
 $data = array();
 foreach ($tree->conf as $conf) {
-    $filter = $conf["ldap_search_filter"];
+    $filter = '(' . $conf["ldap_search_filter"] . ')';
+    if (LDAP_EXCLUDE) {
+        $filter = '(&' . LDAP_EXCLUDE . $filter . ')';
+    }
     if (!$auth->is_phonebook_admin($ldapconn, $auth->user_to_dn($_SERVER["REMOTE_USER"]))) {
-        $filter = '(&(!(employeeType=DISABLED))(' . $filter . '))';
+        $filter = '(&(!(employeeType=DISABLED))' . $filter . ')';
     }
     $search = ldap_search(
         $ldapconn,

--- a/tree.php
+++ b/tree.php
@@ -10,10 +10,14 @@ $auth = new MozillaAuthAdapter();
 
 $data = array();
 foreach ($tree->conf as $conf) {
+    $filter = $conf["ldap_search_filter"];
+    if (!$auth->is_phonebook_admin($ldapconn, $auth->user_to_dn($_SERVER["REMOTE_USER"]))) {
+        $filter = '(&(!(employeeType=DISABLED))(' . $filter . '))';
+    }
     $search = ldap_search(
         $ldapconn,
         $conf["ldap_search_base"],
-        $conf["ldap_search_filter"],
+        $filter,
         $conf["ldap_search_attributes"]
     );
     $data = array_merge($data, ldap_get_entries($ldapconn, $search));


### PR DESCRIPTION
These are a series of small commits necessary for our production phonebook.

An unused variable assignment is removed. For some unknown reason in the past, we copied the basic authentication password into a variable, and then ignored it. Removed.

config-local.php-dist is revised to more clearly indicate default values as defaults. They're all still structured correctly, but now they're clearly defaults, and will need to be revised (as apparent) in order to work correctly.

In the past, we've offered certain unusual SVG effects in three places in the phonebook user interface. Unfortunately, upcoming CSP protections on Phonebook are incompatible with the SVG effects due to browser issues outside of our control. As these are purely cosmetic in nature, we comment them out for now, to avoid triggering CSP.

We add a built-in filter to only show employeeType=DISABLED users when the user performing search is a phonebook_admin. Prior to this patch, we depend on the LDAP server to perform this check. We implement it in phonebook itself to prepare for an upcoming patch that alters how we interact with, and what functionality we depend on from, the LDAP server.

A new config-local parameter is added, allowing us to specify an additional search filter exclusion. When set, the provided filter is AND'd with all searches to subtract any results we deem necessary from the results. This was implemented as a config variable, rather than as code, as we do not wish to publish these filters in the open. An appropriate filter was developed and confirmed in testing, and the dist file has a structurally-correct example available if further testing is desired.

The default LDAP_HOST value is removed. If not provided in config-local, the app exits with a server error rather than proceeding. We should not be proceeding without a valid LDAP_HOST, and the provided default is no longer particularly correct.

Each of these changes has been tested and is live on our dev (and, soon, stage) site.
