### PR TITLE
replace PHP internal auth handling with Apache auth handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,16 @@ Mozilla's internal phonebook app.
 
 *Note:* The app requires LDAP server access. You probably need a [Mozilla-internal VPN connection](https://mana.mozilla.org/wiki/display/SD/VPN) up and running. Without, you can't currently develop on *Phonebook*. You can download your VPN certificate at [login.mozilla.com](https://login.mozilla.com).
 
+## Apache, Authentication, and LDAP
+
+Previous versions of the app authenticated twice - once to Apache (`mod_authnz_ldap`), and then again to PHP itself. This is not compatible with more complex auth methods (`mod_auth_mellon`), which set `REMOTE_USER` without providing a password for LDAP use.
+
+The app now trusts that Apache is configured with `require valid-user`. If `REMOTE_USER` is not set, the app assumes something has gone wrong and refuses to proceed. The app admin is responsible for configuring Apache with a valid auth handler.
+
+This should continue to work correctly under *both* the classic `mod_authnz_ldap` *and* the modern `mod_auth_mellon` methods, but please pay especial attention to this in future testing.
+
+-- 2016-Apr (atoll)
+
 ## Contributing
 
 To contribute, file bugs in Bugzilla and use GitHub for code review:

--- a/config-local.php-dist
+++ b/config-local.php-dist
@@ -8,6 +8,8 @@
 // LDAP
 define('LDAP_HOST', 'pm-ns.mozilla.org');
 define('LDAP_EXCLUDE', '');  // '(!(defaultAttribute=defaultValue))'
+define('LDAP_BIND_DN', 'uid=default,dc=default');
+define('LDAP_BIND_PW', 'defaultDEFAULTdefault');
 
 // Memcache (port number is mandatory)
 define("MEMCACHE_ENABLED", true);

--- a/edit.php
+++ b/edit.php
@@ -9,7 +9,7 @@ $auth = new MozillaAuthAdapter();
 $search = new MozillaSearchAdapter($ldapconn);
 
 $ldap_char_blacklist = array("*", "&", "|", "(", ")", "=");
-$user = str_replace($ldap_char_blacklist, "", $_SERVER["PHP_AUTH_USER"]);
+$user = str_replace($ldap_char_blacklist, "", $_SERVER["REMOTE_USER"]);
 
 $is_admin = $auth->is_phonebook_admin($ldapconn, $auth->user_to_dn($user));
 if (isset($_REQUEST["edit_mail"]) && $is_admin) {

--- a/functions.php
+++ b/functions.php
@@ -1,13 +1,14 @@
 <?php
 
-function ask() {
-  header('WWW-Authenticate: Basic realm="Mozilla Corporation - LDAP Login"');
-}
-
 function wail_and_bail() {
   header('HTTP/1.0 401 Unauthorized');
-  ask();
   print "<h1>401 Unauthorized</h1>";
+  die;
+}
+
+function server_error_and_bail() {
+  header('HTTP/1.0 500 Server Error');
+  print "<h1>500 Server Error</h1>";
   die;
 }
 
@@ -15,20 +16,12 @@ function get_ldap_connection() {
   $ldapconn = ldap_connect(LDAP_HOST);
   $auth = new MozillaAuthAdapter();
 
-  if (!isset($_SERVER["PHP_AUTH_USER"])) {
-    ask();
+  if (!isset($_SERVER["REMOTE_USER"])) {
     wail_and_bail();
-  } else {
-    // Check for validity of login
-    if ($auth->check_valid_user($_SERVER["PHP_AUTH_USER"])) {
-      $user_dn = $auth->user_to_dn($_SERVER["PHP_AUTH_USER"]);
-    } else {
-      wail_and_bail();
-    }
   }
 
-  if (!ldap_bind($ldapconn, $user_dn, $_SERVER['PHP_AUTH_PW'])) {
-    wail_and_bail();
+  if (!ldap_bind($ldapconn, LDAP_BIND_DN, LDAP_BIND_PW)) {
+    server_error_and_bail();
     die(ldap_error($ldapconn));
   }
 

--- a/search.php
+++ b/search.php
@@ -30,5 +30,5 @@ if (!in_array($format, $output_formats) || !file_exists("output-$format.inc")) {
 }
 require_once("output-$format.inc");
 $function = "output_$format";
-$dn = $auth->user_to_dn($_SERVER["PHP_AUTH_USER"]);
+$dn = $auth->user_to_dn($_SERVER["REMOTE_USER"]);
 call_user_func($function, $entries, $auth->is_phonebook_admin($ldapconn, $dn));


### PR DESCRIPTION
This is a significant change to Phonebook, replacing all internal PHP authentication handling with the assumption that Apache, rather than PHP, will handle authentication for us.

We are replacing Phonebook's authentication handler with something more complex that we do not wish to implement in PHP. Therefore, this patch simply removes all PHP auth handling and assumes that Apache either has, or has not, set a REMOTE_USER environment variable for us.

It is assumed that the webserver associated with Phonebook will refuse requests unless a valid user is provided. We will ensure that our servers are configured in this manner when we deploy, but other users should take note as well.

This pull request depends critically on pull #20, and must not be merged until both pull #20 is closed AND we are ready to deploy production Phonebook with this change. This is a single commit, rather than a series of commits, to provide clear visibility into the precise changes necessary. You can see what this commit looks like when rebased onto pull #20 by looking at c2e8f8acc727bb87871451a007a02a7867b5f22c on my personal branch.

This change has also been tested on our dev (and, soon, stage) site.
