### PR TITLE
Replace our custom LDAP escaping with ldap_escape() backported from PHP 5.6.

### DIFF
--- a/edit.php
+++ b/edit.php
@@ -25,7 +25,7 @@ if (!empty($_POST)) {
   foreach ($editable_fields as $editable_field) {
     if (isset($_POST[$editable_field])) {
         if(in_array($editable_field, $MONKEY_FREE_ARRAY)){
-            $_POST[$editable_field][0] = trim(preg_replace('/[^\p{L}\s]/u','', $_POST[$editable_field][0]));
+            $_POST[$editable_field][0] = trim(ldap_escape($_POST[$editable_field][0], null, LDAP_ESCAPE_FILTER));
         }
         $new_user_data[$editable_field] = $_POST[$editable_field];
     }


### PR DESCRIPTION
Per pull request #11 and various other bugs and pull requests over time, we are not handling non-Latin1 input appropriately. This pull request attempts to fix that by using PHP core's ldap_escape() function rather than hand-crafted regular expressions.

r? @tofumatt for sanity-check and basic testing; I will try to test on dev as well, to check for syntax issues and so on. And then we'll need to get a security review, but sanity checks come first.
