### PR TITLE
Resynchronize production codebase with the repository.

### DIFF
--- a/config.php
+++ b/config.php
@@ -162,7 +162,7 @@ class MozillaSearchAdapter extends SearchAdapter {
     $ldapconn = get_ldap_connection();
     parent::__construct($ldapconn);
     $this->auth = new MozillaAuthAdapter();
-    $this->dn = $this->auth->user_to_dn($_SERVER["PHP_AUTH_USER"]);
+    $this->dn = $this->auth->user_to_dn($_SERVER["REMOTE_USER"]);
     $this->phonebook_admin = $this->auth->is_phonebook_admin($ldapconn, $this->dn);
   }
 


### PR DESCRIPTION
68b2018 is present locally on the production deployment but was not included in pull request #21. Without this patch, the site simply fails to operate, as there is no aliasing of `PHP_AUTH_USER` to `REMOTE_USER` inside any reasonable Apache config.

Each remaining variation was reverted as part of the review process for pull #20 and pull #21 with @tofumatt, and should not be ported forward into the production branch.

I'll merge this in a moment to bring the repository into sync, and then push the final state of master to dev/stage so we can verify that everything is still working as expected.
