### PR TITLE
Only replace LDAP attributes if the user has changed them.

### DIFF
--- a/edit.php
+++ b/edit.php
@@ -48,6 +48,12 @@ if (!empty($_POST)) {
         fb("Failure on $key => ". print_r($value, TRUE) ." for $edit_user");
       }
       fb("Success on $key => ". print_r($value, TRUE) ." for $edit_user");
+    } elseif (is_array($new_user_data[strtolower($key)])) {
+      if (empty(array_diff($user_data[strtolower($key)], $new_user_data[strtolower($key)]))) {
+        unset($new_user_data[$key]);
+      }
+    } elseif ($user_data[strtolower($key)] == $value) {
+      unset($new_user_data[$key]);
     }
   }
 


### PR DESCRIPTION
This compares the new entry values to the existing values and only replaces LDAP values that have changed which simplifies the LDAP ldif transactions and audit trails.

Related Bugzilla ticket : [Bug 1286969](https://bugzilla.mozilla.org/show_bug.cgi?id=1286969)

This went to stage but not production and was superseded by #38
