### PR TITLE
implement support for RESULT_SIZE_LIMIT to allow limiting result size

### DIFF
--- a/config-local.php-dist
+++ b/config-local.php-dist
@@ -17,3 +17,6 @@ $memcache_servers = array(
     'localhost:11211',
 );
 define('MEMCACHE_PREFIX', 'phonebook-default');
+
+// Restrict the number of results returned for user-initiated searches (0 == no limit)
+define('RESULT_SIZE_LIMIT', 0);


### PR DESCRIPTION
By default, it's disabled. When enabled, it results in a PHP error, followed by the partial result set:

`Warning: ldap_search(): Partial search results returned: Sizelimit exceeded in /data/www/phonebook.allizom.org/phonebook/init.php on line 85`

If someone is more capable with PHP error handling than I am, a more useful banner could be presented.
