### PR TITLE
Reintroduce LDAP write optimizations for Infosec [#1286969]

### DIFF
--- a/edit.php
+++ b/edit.php
@@ -41,6 +41,25 @@ if (!empty($_POST)) {
 
   // Save the attributes
   foreach ($new_user_data as $key => $value) {
+    // strip the 'count' elements from user_data
+    if (is_array($user_data[strtolower($key)]) and
+        array_key_exists('count', $user_data[strtolower($key)])) {
+      unset($user_data[strtolower($key)]['count']);
+    }
+    // normalize user_data to the type of new_user_data
+    if (is_string($value)) {
+      if (is_array($user_data[strtolower($key)]) and
+          count($user_data[strtolower($key)]) == 1) {
+        $user_data[strtolower($key)] = $user_data[strtolower($key)][0];
+      }
+    } else {
+      if (is_string($user_data[strtolower($key)])) {
+        $user_data[strtolower($key)] = array($user_data[strtolower($key)]);
+      } elseif (is_null($user_data[strtolower($key)])) {
+        $user_data[strtolower($key)] = array();
+      }
+    }
+
     if (!isset($user_data[strtolower($key)])) {
       if (!ldap_add($ldapconn,
                     $auth->email_to_dn($ldapconn, $edit_user),
@@ -49,7 +68,7 @@ if (!empty($_POST)) {
       }
       fb("Success on $key => ". print_r($value, TRUE) ." for $edit_user");
     } elseif (is_array($new_user_data[strtolower($key)])) {
-      if (count(array_diff($user_data[strtolower($key)], $new_user_data[strtolower($key)])) == 0) {
+      if ($user_data[strtolower($key)] === $new_user_data[strtolower($key)]) {
         unset($new_user_data[$key]);
       }
     } elseif ($user_data[strtolower($key)] == $value) {


### PR DESCRIPTION
# Summary

Changes the `count` `array_diff` method of comparing arrays to determine if a change was made to an identity comparison (`===`).

Related Bugzilla ticket : [Bug 1286969](https://bugzilla.mozilla.org/show_bug.cgi?id=1286969)

# History

The history related to this feature
- PR #26 introduced the feature but had a bug related to the fact that the php [empty](http://php.net/manual/en/function.empty.php) function didn't support expressions until version 5.5.0.
- PR #26 was reverted due to the bug
- PR #28 was created which reintroduced the feature and fixed the bug in #26 by using [count](http://php.net/manual/en/function.count.php) to determine if the [array_diff](http://php.net/manual/en/function.array-diff.php) results were equal to 0. This worked around the fact that `empty` didn't support expressions.
- PR #28 however still relied on the `array_diff` function to compare the two arrays. The problem is that this function only returns the values in the first array which aren't present in the second array. It does not return values which are in the second array but not in the first array. As a result when users add either a new "office" value or a new "phone number" the check wrongly believes that there's been no change and ignores the addition.
- This PR fixes the bug present in #26 and #28 by instead doing a straight identity comparison of the arrays using `===`. This will _only_ consider the arrays to be the same (and thus not requiring an LDAP update) if they "[have the same key/value pairs in the same order and of the same types](http://php.net/manual/en/language.operators.array.php)".
# Testing

The testing which I did not do during #26 and #28 which would have surfaced this bug is :
- Edit my entry in phonebook
- Add a new phone number and submit
- Confirm that the new phone number is present

I've done this test with the new code and confirmed that it works.

Here are the other tests I've done with the code and confirmed the expected behavior
- Modified the "I work on" field
- Added a phone number
- Removed a phone number
- Added an office
- Removed an office
- Modified my bugzilla email address
- Uploaded a new avatar photo
- Added an email address
- Removed an email address
- Added one email address and removed another email address in the same submission
- Added an extension
- Removed an extension
- Added an IM Account
- Removed an IM account
- Added one IM account and removed another IM account in the same submission
- Added a github username
- Removed a github username
- Modified the first phone number when there were more than one phone number in the list
- Modified the last phone number when there were more than one phone number in the list

In running these tests I've confirmed that not only does the app behave as expected but that the new feature of reduced LDAP noise also works as expected and for each change the only LDAP changes executed are the modified field (plus the standard changes to "entryCSN", "modifiersName" and "modifyTimestamp")

I'd also like to apologize for introducing the two PRs that, had I tested them fully, would have revealed these bugs. I should have tested them more thoroughly.
