### PR TITLE
Fix manager links to use the non-fragment search form. [#1301141]

### DIFF
--- a/output-html.inc
+++ b/output-html.inc
@@ -72,7 +72,7 @@ function output_html_dn_to_email($dn) {
 function output_html_manager($m) {
   $m["email"] = htmlspecialchars(output_html_dn_to_email($m["dn"]));
   $clean_cn = htmlspecialchars($m['cn']);
-  return "<p class=\"manager\">Manager: <a href=\"#search/{$m['email']}\">{$clean_cn}</a><a class='org-chart' href='tree.php#search/{$m['email']}'>(Org)</a></p>";
+  return "<p class=\"manager\">Manager: <a href=\"?search/{$m['email']}\">{$clean_cn}</a><a class='org-chart' href='tree.php?search/{$m['email']}'>(Org)</a></p>";
 }
 
 function output_html_title($t) {


### PR DESCRIPTION
I verified that this works in my dev environment to fix the specific instance of #fragment problems described in bug 1301141. @globau, do you see any issues if I ship this bugfix with tomorrow's prod deploy?
