### PR TITLE
Use relative HREF to pic.php, remove BASEPATH. [#1277548]

### DIFF
--- a/config.php
+++ b/config.php
@@ -208,7 +208,7 @@ class MozillaSearchAdapter extends SearchAdapter {
 
   public function preprocess_entry(&$entry) {
     if (preg_match("/mail=(.*@.+),o=/", $entry["dn"], $m)) {
-      $entry["picture"] = BASEPATH ."pic.php?mail=". $m[1];
+      $entry["picture"] = "pic.php?mail=". $m[1];
     }
   }
 }

--- a/constants.php
+++ b/constants.php
@@ -39,9 +39,6 @@ $office_cities = array(
     'Other' => 'Other'
 );
 
-$protocol = isset($_SERVER["HTTPS"]) ? "https://" : "http://";
-define("BASEPATH", $protocol . $_SERVER["HTTP_HOST"] . dirname($_SERVER["REQUEST_URI"]) .'/');
-
 $shirt_sizes = array(
    'XS (M)',
    'S (M)',


### PR DESCRIPTION
Rather than trying to repair the BASEPATH code, let's just do what we do everywhere else in Phonebook and go with href="pic.php", removing BASEPATH entirely.
