### PR TITLE
Handle zero-or-more multi-value fields correctly. [#1172956]

### DIFF
--- a/constants.php
+++ b/constants.php
@@ -21,6 +21,10 @@ $editable_fields = array(
   'employeeType', 'bugzillaEmail', 'shirtsize', 'b2gNumber', 'roomNumber', 'githubProfile'
 );
 
+$deleteable_fields = array(
+  'emailAlias', 'mobile', 'im',
+);
+
 $office_cities = array(
     'Mountain View' => 'US', 
     'San Francisco' => 'US',

--- a/edit.php
+++ b/edit.php
@@ -38,6 +38,15 @@ if (!empty($_POST)) {
   }
 
   $edit->cook_incoming($new_user_data, $is_admin);
+  // The user may have cleared the 'zero or more' fields on the edit.php page.
+  // That means their POST won't contain any values for those fields. So we
+  // explicitly check for their absence and force them to an empty array here,
+  // which instructs ldap_modify() to delete all items, as the user intended.
+  foreach ($deleteable_fields as $attribute) {
+    if (!isset($new_user_data[$attribute])) {
+      $new_user_data[$attribute] = array();
+    }
+  }
 
   // Save the attributes
   foreach ($new_user_data as $key => $value) {


### PR DESCRIPTION
This patch ensures that users can delete the last value from each of the three multi-value fields that permit zero or more entries in LDAP. Tested and verified to permit modifying any of the values, removing individual values as usual, and deleting one or all values for a given field. r? anyone.
