### PR TITLE
Search the field "other" as well. [#707209]

### DIFF
--- a/config.php
+++ b/config.php
@@ -174,7 +174,7 @@ class MozillaSearchAdapter extends SearchAdapter {
   );
   public $search_fields = array(
     'cn', 'bugzillaEmail', 'mail', 'emailAlias', 'im', 'physicalDeliveryOfficeName',
-    'description', 'telephoneNumber', 'mobile', 'b2gNumber', 'githubProfile'
+    'description', 'telephoneNumber', 'mobile', 'b2gNumber', 'githubProfile', 'other'
   );
   public $conf = array(
     "ldap_sort_order" => "sn"


### PR DESCRIPTION
For whatever reason, LDAP has two fields that are free-form text input for users. One is the "I work on" field, the other is the freeform "other" field. For whatever reason, we've only searched the former in the past. This comes rather as a surprise when we search a lot of other fields (like hidden, non-displayed locations) but not one users specifically use to describe themselves.

If we agree that we should add this field to the search fields, then this patch will do so, assuming that LDAP allows us to freetext search the field. Untested, pending discussion.
