### PR TITLE
Write out employeeType as the organization, not department. [#558940]

### DIFF
--- a/output-vcard.inc
+++ b/output-vcard.inc
@@ -34,7 +34,7 @@ function vcard_picture($url) {
 }
 
 function vcard_employeetype($a) {
-  return "ORG:;{$a[0]}\n";
+  return "ORG:{$a[0]}\n";
 }
 
 function vcard_extension($n) {


### PR DESCRIPTION
The ORG field is constructed from the LDAP field 'employeeType', which is derived down into one of:

"Mozilla Corporation"
"Mozilla Japan"
"Mozilla Foundation"

These are all, technically, departments of Mozilla, except that no ORG is listed at all.

These values are safed for the actual details of employeeType (contractor, etc) and we already implement them in the field output anyways.

So this patch applies the fix proposed 7 years ago, moving e.g. "Mozilla Corporation" to the Organization field in the VCARD output, rather than the Department field. r? anyone
