### PR TITLE
Fix org tree behavior from glob rewrite

### DIFF
--- a/config-srihashes.php
+++ b/config-srihashes.php
@@ -4,6 +4,6 @@ $GLOBALS["SRIHASHES"] = array(
 "css/font-awesome.min.css" => "sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN",
 "css/style.css" => "sha384-3+qaYNVG3XTPDSYGxgT9IhtdO60ELHYGV2E8VQ2sqVHOaIDe0iThsTeqyJnm6VxK",
 "js/jquery-min.js" => "sha384-xBuQ/xzmlsLoJpyjoggmTEz8OWUFM0/RC5BsqQBDX2v5cMvDHcMakNTNrHIW2I5f",
-"js/phonebook.js" => "sha384-OHOQgREvSvnUyybCf6lJarobcZSqJcfLNbHQbjutMb3rja7ChTPgzTo86rQqCFaZ",
+"js/phonebook.js" => "sha384-LrlUJZhEeTEgl+4p9m0i01uIvFHdaaPp+mks6Rz2qcruKnPI027l84KXc5PkCqGG",
 );
 ?>

--- a/config-srihashes.php
+++ b/config-srihashes.php
@@ -4,6 +4,6 @@ $GLOBALS["SRIHASHES"] = array(
 "css/font-awesome.min.css" => "sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN",
 "css/style.css" => "sha384-3+qaYNVG3XTPDSYGxgT9IhtdO60ELHYGV2E8VQ2sqVHOaIDe0iThsTeqyJnm6VxK",
 "js/jquery-min.js" => "sha384-xBuQ/xzmlsLoJpyjoggmTEz8OWUFM0/RC5BsqQBDX2v5cMvDHcMakNTNrHIW2I5f",
-"js/phonebook.js" => "sha384-LrlUJZhEeTEgl+4p9m0i01uIvFHdaaPp+mks6Rz2qcruKnPI027l84KXc5PkCqGG",
+"js/phonebook.js" => "sha384-UtaPsPJhFe6GkhLymhAhCcgxG6XBJPHApFXbf7eSCWnfMxCjEVEafhhHt6f/WrrT",
 );
 ?>

--- a/config-srihashes.php
+++ b/config-srihashes.php
@@ -4,6 +4,6 @@ $GLOBALS["SRIHASHES"] = array(
 "css/font-awesome.min.css" => "sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN",
 "css/style.css" => "sha384-3+qaYNVG3XTPDSYGxgT9IhtdO60ELHYGV2E8VQ2sqVHOaIDe0iThsTeqyJnm6VxK",
 "js/jquery-min.js" => "sha384-xBuQ/xzmlsLoJpyjoggmTEz8OWUFM0/RC5BsqQBDX2v5cMvDHcMakNTNrHIW2I5f",
-"js/phonebook.js" => "sha384-UtaPsPJhFe6GkhLymhAhCcgxG6XBJPHApFXbf7eSCWnfMxCjEVEafhhHt6f/WrrT",
+"js/phonebook.js" => "sha384-ffu8PSTE2WHF1FCl7L1xEmOWlZW5EWYGXMKxWBa5RKngWHlXWlN/KEWpzbzPcZI3",
 );
 ?>

--- a/config-srihashes.php
+++ b/config-srihashes.php
@@ -4,6 +4,6 @@ $GLOBALS["SRIHASHES"] = array(
 "css/font-awesome.min.css" => "sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN",
 "css/style.css" => "sha384-3+qaYNVG3XTPDSYGxgT9IhtdO60ELHYGV2E8VQ2sqVHOaIDe0iThsTeqyJnm6VxK",
 "js/jquery-min.js" => "sha384-xBuQ/xzmlsLoJpyjoggmTEz8OWUFM0/RC5BsqQBDX2v5cMvDHcMakNTNrHIW2I5f",
-"js/phonebook.js" => "sha384-br584pnoJl5MMYZToUmcjk0tTj5Zcjwq9WafKRZUuUyTDzlWCGuuctYITZeYQxAW",
+"js/phonebook.js" => "sha384-OHOQgREvSvnUyybCf6lJarobcZSqJcfLNbHQbjutMb3rja7ChTPgzTo86rQqCFaZ",
 );
 ?>

--- a/js/phonebook.js
+++ b/js/phonebook.js
@@ -408,9 +408,6 @@ TreePage.prototype.showCard = function(mail) {
   $('html').animate({ scrollTop: $person.offset().top - 2 });
   $('#text').val(mail).keyup();
 
-  // highlight matches
-  $person.addClass('highlighted');
-
   page.showThrobber();
   $.ajax({
     url: 'search.php?format=html&exact_search=true&query=' + encodeURIComponent(mail),

--- a/js/phonebook.js
+++ b/js/phonebook.js
@@ -409,7 +409,6 @@ TreePage.prototype.showCard = function(mail) {
   $('#text').val(mail).keyup();
 
   // highlight matches
-  $('#orgchart').addClass('filter-view');
   $person.addClass('highlighted');
 
   page.showThrobber();
@@ -434,7 +433,6 @@ TreePage.prototype.deselectAllNodes = function() {
   $('#person').empty();
   $('#search-limited').remove();
   function reset(id) {
-    $(id).removeClass('filter-view');
     $(id + ' li.selected').removeClass('selected');
   }
   reset('#orgchart');
@@ -442,6 +440,7 @@ TreePage.prototype.deselectAllNodes = function() {
 }
 
 TreePage.prototype.dehighlightAllNodes = function() {
+  $('#orgchart').removeClass('filter-view');
   function reset(id) {
     $(id + ' li.highlighted').removeClass('highlighted');
   }

--- a/js/phonebook.js
+++ b/js/phonebook.js
@@ -338,6 +338,7 @@ TreePage.prototype.search = function(query) {
     $.getJSON(url, function(searchResult) {
       // no results
       if (searchResult.count === 0) {
+        page.clear();
         page.noResults($('#person'));
         resolve();
         return;
@@ -355,15 +356,8 @@ TreePage.prototype.search = function(query) {
         $(id).addClass('highlighted');
       });
 
-      // collapse
-      page.expandAllNodes();
-      $('#orgchart li:not(.leaf)').each(function() {
-        var $parent = $(this);
-        var $children = page.childNodes($parent);
-        if ($children.find('.highlighted').length === 0) {
-          page.collapseNode($parent);
-        }
-      });
+      // collapse all non-highlighted nodes
+      page.collapseAllNodes();
 
       // expand matches
       var $person = $('#orgchart li.highlighted');
@@ -373,6 +367,13 @@ TreePage.prototype.search = function(query) {
 
       // and bring into view
       $('html').animate({ scrollTop: $person.first().offset().top - 2 });
+
+      // display the precise email match, if any
+      $.each(searchResult.users, function() {
+          if (this.mail == query) {
+              page.showCard(this.mail);
+          }
+      });
 
       resolve();
     }).fail(function(jx, textStatus, errorThrown) {
@@ -384,9 +385,21 @@ TreePage.prototype.search = function(query) {
   });
 };
 
+TreePage.prototype.collapseAllNodes = function() {
+  var page = this;
+  page.expandAllNodes();
+  $('#orgchart li:not(.leaf)').each(function() {
+    var $parent = $(this);
+    var $children = page.childNodes($parent);
+    if ($children.find('.highlighted').length === 0) {
+      page.collapseNode($parent);
+    }
+  });
+};
+
 TreePage.prototype.showCard = function(mail) {
   var page = this;
-  page.clear();
+  page.deselectAllNodes();
   window.history.pushState({}, '',
     window.location.pathname + '?search/' + mail);
 
@@ -394,6 +407,10 @@ TreePage.prototype.showCard = function(mail) {
   $person.addClass('selected');
   $('html').animate({ scrollTop: $person.offset().top - 2 });
   $('#text').val(mail).keyup();
+
+  // highlight matches
+  $('#orgchart').addClass('filter-view');
+  $person.addClass('highlighted');
 
   page.showThrobber();
   $.ajax({
@@ -413,16 +430,28 @@ TreePage.prototype.showCard = function(mail) {
   });
 };
 
-TreePage.prototype.clear = function() {
+TreePage.prototype.deselectAllNodes = function() {
+  $('#person').empty();
+  $('#search-limited').remove();
   function reset(id) {
     $(id).removeClass('filter-view');
     $(id + ' li.selected').removeClass('selected');
-    $(id + ' li.highlighted').removeClass('highlighted');
   }
-  $('#person').empty();
-  $('#search-limited').remove();
   reset('#orgchart');
   reset('#orphans');
+}
+
+TreePage.prototype.dehighlightAllNodes = function() {
+  function reset(id) {
+    $(id + ' li.highlighted').removeClass('highlighted');
+  }
+  reset('#orgchart');
+  reset('#orphans');
+}
+
+TreePage.prototype.clear = function() {
+  this.deselectAllNodes();
+  this.dehighlightAllNodes();
   this.expandAllNodes();
   this.collapseNode($('#managerless'));
 };

--- a/js/phonebook.js
+++ b/js/phonebook.js
@@ -630,8 +630,8 @@ $(function() {
       this.href = this.pathname + queryString;
     });
 
-    // don't rerun identical queries
-    if (filter === $text.data('last')) {
+    // don't rerun identical queries, except for the empty-string query
+    if (filter !== '' && filter === $text.data('last')) {
       return;
     }
     $text.data('last', filter);


### PR DESCRIPTION
Glob's rewrite of Phonebook jquery works well, but was missing certain behaviors in the org tree section (click to display card, etc). With this change, it now behaves like the old org tree.