### PR TITLE
refuse to load userpics for disabled users [#1419457]

### DIFF
--- a/pic.php
+++ b/pic.php
@@ -39,14 +39,14 @@ if ($memcache_on && ($cached_pic = $memcache->get(MEMCACHE_PREFIX . $_GET['mail'
 }
 
 $search = ldap_search(
-  $ldapconn, 'dc=mozilla', "(mail=". $_GET['mail'] .")", array('jpegPhoto')
+  $ldapconn, 'dc=mozilla', "(mail=". $_GET['mail'] .")", array('jpegPhoto', 'employeeType')
 );
 
 if ($search) {
   $entry = ldap_first_entry($ldapconn, $search);
   if ($entry) {
     $attributes = ldap_get_attributes($ldapconn, $entry);
-    if (!empty($attributes['jpegPhoto'])) {
+    if ($attributes['employeeType'] != 'DISABLED' && !empty($attributes['jpegPhoto'])) {
       $jpeg = ldap_get_values_len($ldapconn, $entry, 'jpegPhoto');
       if ($jpeg) {
         $pic = $jpeg[0];


### PR DESCRIPTION
If a user is employeeType == DISABLED, refuse to load their userpic. Phonebook admins won't be able to see userpics for disabled users with this fix in place, but Phonebook admin accounts should never be used on Phonebook except for admin activities, which likely does not include viewing userpics for disabled users.