### PR TITLE
Bugmail field should link to bugzilla profile

### DIFF
--- a/output-html.inc
+++ b/output-html.inc
@@ -85,7 +85,7 @@ function output_html_telephonenumber($s) {
 
 function output_html_bugzillaemail($s) {
   $s = htmlspecialchars($s);
-  return "<div class=\"bugmail\">Bugmail: <a title=\"Bugmail\" href=\"mailto:$s\">$s</a></div>";
+  return "<div class=\"bugmail\">Bugmail: <a title=\"Bugmail\" href=\"https://bugzilla.mozilla.org/user_profile?login=$s\">$s</a></div>";
 }
 
 function output_html_cn($s){


### PR DESCRIPTION
Currently, clicking on the email address next to the "Bugmail" field, links to a mailto: URL.
This patch makes it so that the link goes to `https://bugzilla.mozilla.org/user_profile?login=` instead.

I'd find that useful :-)